### PR TITLE
h2 4.2.0 

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -32,6 +32,7 @@ test:
     - h2
   requires:
     - python
+    - pip
     - pytest
     - hypothesis >=6.119.4,<7
   commands:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -6,7 +6,6 @@ package:
   version: {{ version }}
 
 source:
-  fn: {{ name }}-{{ version }}.tar.gz
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
   sha256: c8a52129695e88b1a0578d8d2cc6842bbd79128ac685463b887ee278126ad01f
 
@@ -22,8 +21,8 @@ requirements:
     - pip
   run:
     - python
-    - hyperframe    >=6.0,<7
-    - hpack         >=4.0,<5
+    - hyperframe    >=6.1,<7
+    - hpack         >=4.1,<5
 
 test:
   imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -56,7 +56,7 @@ about:
     control. This ensures that it can seamlessly work in all kinds
     of environments, from single-threaded code to Twisted.
   dev_url: https://github.com/python-hyper/hyper-h2
-  doc_url: https://python-hyper.org/projects/hyper-h2
+  doc_url: https://python-hyper.org
 
 extra:
   recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -29,7 +29,7 @@ test:
     - h2
 
 about:
-  home: http://python-hyper.org/h2/
+  home: https://python-hyper.org/projects/hyper-h2
   license: MIT
   license_family: MIT
   license_file: LICENSE

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -33,7 +33,7 @@ test:
   requires:
     - python
     - pip
-    - pytest
+    - pytest >=8.3.3,<9
     - hypothesis >=6.119.4,<7
   commands:
     - pip check

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,6 +11,7 @@ source:
   sha256: c8a52129695e88b1a0578d8d2cc6842bbd79128ac685463b887ee278126ad01f
 
 build:
+  skip: true  # [py<39]
   number: 0
   script: {{ PYTHON }} -m pip install . --no-deps -vv
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
 build:
   skip: true  # [py<39]
   number: 0
-  script: {{ PYTHON }} -m pip install . --no-deps -vv
+  script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
 
 requirements:
   host:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -45,7 +45,17 @@ about:
   license_family: MIT
   license_file: LICENSE
   summary: HTTP/2 State-Machine based protocol implementation
+  description: |
+    h2 is a HTTP/2 protocol stack, written entirely in Python.
+    The goal of h2 is to be a common HTTP/2 stack for the Python
+    ecosystem, usable in all programs regardless of concurrency
+    model or environment.
+    To achieve this, h2 is entirely self-contained: it does
+    no I/O of any kind, leaving that up to a wrapper library to
+    control. This ensures that it can seamlessly work in all kinds
+    of environments, from single-threaded code to Twisted.
   dev_url: https://github.com/python-hyper/hyper-h2
+  doc_url: https://python-hyper.org/projects/hyper-h2
 
 extra:
   recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -19,6 +19,7 @@ requirements:
     - python
     - setuptools
     - pip
+    - wheel
   run:
     - python
     - hyperframe    >=6.1,<7
@@ -27,6 +28,9 @@ requirements:
 test:
   imports:
     - h2
+  commands:
+    - pip check
+    - python -c "from importlib.metadata import version; assert(version('{{ name }}')=='{{ version }}')"
 
 about:
   home: https://python-hyper.org/projects/hyper-h2

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
 build:
   skip: true  # [py<39]
   number: 0
-  script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
+  script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vvv
 
 requirements:
   host:
@@ -26,11 +26,17 @@ requirements:
     - hpack         >=4.1,<5
 
 test:
+  source_files:
+    - tests
   imports:
     - h2
+  requires:
+    - python
+    - pytest
   commands:
     - pip check
     - python -c "from importlib.metadata import version; assert(version('{{ name }}')=='{{ version }}')"
+    - pytest -vv tests
 
 about:
   home: https://python-hyper.org/projects/hyper-h2

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -41,7 +41,7 @@ test:
     - pytest -vv tests
 
 about:
-  home: https://python-hyper.org/projects/hyper-h2
+  home: https://github.com/python-hyper/h2
   license: MIT
   license_family: MIT
   license_file: LICENSE

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -33,6 +33,7 @@ test:
   requires:
     - python
     - pytest
+    - hypothesis >=6.119.4,<7
   commands:
     - pip check
     - python -c "from importlib.metadata import version; assert(version('{{ name }}')=='{{ version }}')"

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -55,7 +55,7 @@ about:
     no I/O of any kind, leaving that up to a wrapper library to
     control. This ensures that it can seamlessly work in all kinds
     of environments, from single-threaded code to Twisted.
-  dev_url: https://github.com/python-hyper/hyper-h2
+  dev_url: https://github.com/python-hyper/h2
   doc_url: https://python-hyper.org
 
 extra:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,5 @@
 {% set name = "h2" %}
-{% set version = "4.0.0" %}
-{% set sha256 = "bb7ac7099dd67a857ed52c815a6192b6b1f5ba6b516237fc24a085341340593d" %}
+{% set version = "4.2.0" %}
 
 package:
   name: {{ name|lower }}
@@ -9,10 +8,10 @@ package:
 source:
   fn: {{ name }}-{{ version }}.tar.gz
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: {{ sha256 }}
+  sha256: c8a52129695e88b1a0578d8d2cc6842bbd79128ac685463b887ee278126ad01f
 
 build:
-  number: 3
+  number: 0
   script: {{ PYTHON }} -m pip install . --no-deps -vv
 
 requirements:


### PR DESCRIPTION
h2 4.2.0 

**Destination channel:** Defaults

### Links

- [PKG-8585]
- dev_url:        https://github.com/python-hyper/hyper-h2/tree/v4.2.0
- conda_forge:    https://github.com/conda-forge/h2-feedstock
- pypi:           https://pypi.org/project/h2/4.2.0
- pypi inspector: https://inspector.pypi.io/project/h2/4.2.0

### Explanation of changes:

- new version number


[PKG-8585]: https://anaconda.atlassian.net/browse/PKG-8585?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ